### PR TITLE
Flip Operation.Inputs to Path:SlotRef ordering.

### DIFF
--- a/funcs/moduleOrder.go
+++ b/funcs/moduleOrder.go
@@ -180,8 +180,8 @@ func (s slotRefs) Less(i, j int) bool {
 func inputSlotRefs(s api.StepUnion) (r []api.SlotRef) {
 	switch x := s.(type) {
 	case api.Operation:
-		for k := range x.Inputs {
-			r = append(r, k)
+		for _, ref := range x.Inputs {
+			r = append(r, ref)
 		}
 		return r
 	case api.Module:

--- a/funcs/moduleOrder_test.go
+++ b/funcs/moduleOrder_test.go
@@ -27,17 +27,17 @@ func TestNilRelationLexicalOrdering(t *testing.T) {
 
 func TestFanoutLexicalOrdering(t *testing.T) {
 	basting := api.Module{Steps: map[api.StepName]api.StepUnion{
-		"stepD": api.Operation{Inputs: map[api.SlotRef]api.AbsPath{
-			{"step0", "theslot"}: "/",
+		"stepD": api.Operation{Inputs: map[api.AbsPath]api.SlotRef{
+			"/": {"step0", "theslot"},
 		}},
-		"stepB": api.Operation{Inputs: map[api.SlotRef]api.AbsPath{
-			{"step0", "theslot"}: "/",
+		"stepB": api.Operation{Inputs: map[api.AbsPath]api.SlotRef{
+			"/": {"step0", "theslot"},
 		}},
-		"stepA": api.Operation{Inputs: map[api.SlotRef]api.AbsPath{
-			{"step0", "theslot"}: "/",
+		"stepA": api.Operation{Inputs: map[api.AbsPath]api.SlotRef{
+			"/": {"step0", "theslot"},
 		}},
-		"stepC": api.Operation{Inputs: map[api.SlotRef]api.AbsPath{
-			{"step0", "theslot"}: "/",
+		"stepC": api.Operation{Inputs: map[api.AbsPath]api.SlotRef{
+			"/": {"step0", "theslot"},
 		}},
 		"step0": api.Operation{Outputs: map[api.SlotName]api.AbsPath{
 			"theslot": "/",
@@ -60,11 +60,11 @@ func TestFanInLexicalOrdering(t *testing.T) {
 		"stepB": api.Operation{Outputs: map[api.SlotName]api.AbsPath{"theslot": "/"}},
 		"stepA": api.Operation{Outputs: map[api.SlotName]api.AbsPath{"theslot": "/"}},
 		"stepC": api.Operation{Outputs: map[api.SlotName]api.AbsPath{"theslot": "/"}},
-		"step9": api.Operation{Inputs: map[api.SlotRef]api.AbsPath{
-			{"stepA", "theslot"}: "/a",
-			{"stepB", "theslot"}: "/b",
-			{"stepC", "theslot"}: "/c",
-			{"stepD", "theslot"}: "/d",
+		"step9": api.Operation{Inputs: map[api.AbsPath]api.SlotRef{
+			"/a": {"stepA", "theslot"},
+			"/b": {"stepB", "theslot"},
+			"/c": {"stepC", "theslot"},
+			"/d": {"stepD", "theslot"},
 		}},
 	}}
 	order, err := ModuleOrderSteps(basting)
@@ -84,15 +84,15 @@ func TestSimpleLinearOrdering(t *testing.T) {
 			Outputs: map[api.SlotName]api.AbsPath{"aslot": "/"},
 		},
 		"stepB": api.Operation{
-			Inputs:  map[api.SlotRef]api.AbsPath{{"stepA", "aslot"}: "/"},
+			Inputs:  map[api.AbsPath]api.SlotRef{"/": {"stepA", "aslot"}},
 			Outputs: map[api.SlotName]api.AbsPath{"xslot": "/"},
 		},
 		"stepD": api.Operation{
-			Inputs:  map[api.SlotRef]api.AbsPath{{"stepB", "xslot"}: "/"},
+			Inputs:  map[api.AbsPath]api.SlotRef{"/": {"stepB", "xslot"}},
 			Outputs: map[api.SlotName]api.AbsPath{"xslot": "/"},
 		},
 		"stepC": api.Operation{
-			Inputs: map[api.SlotRef]api.AbsPath{{"stepD", "xslot"}: "/"},
+			Inputs: map[api.AbsPath]api.SlotRef{"/": {"stepD", "xslot"}},
 		},
 	}}
 	order, err := ModuleOrderSteps(basting)
@@ -122,8 +122,8 @@ func TestComplexOrdering(t *testing.T) {
 			Outputs: map[api.SlotName]api.AbsPath{"slot": "/"},
 		},
 		"stepB": api.Operation{
-			Inputs: map[api.SlotRef]api.AbsPath{
-				{"stepA", "slot"}: "/",
+			Inputs: map[api.AbsPath]api.SlotRef{
+				"/": {"stepA", "slot"},
 			},
 			Outputs: map[api.SlotName]api.AbsPath{"slot": "/"},
 		},
@@ -131,66 +131,66 @@ func TestComplexOrdering(t *testing.T) {
 			Outputs: map[api.SlotName]api.AbsPath{"slot": "/"},
 		},
 		"stepD": api.Operation{
-			Inputs: map[api.SlotRef]api.AbsPath{
-				{"stepC", "slot"}: "/",
+			Inputs: map[api.AbsPath]api.SlotRef{
+				"/": {"stepC", "slot"},
 			},
 			Outputs: map[api.SlotName]api.AbsPath{"slot": "/"},
 		},
 		"stepE": api.Operation{
-			Inputs: map[api.SlotRef]api.AbsPath{
-				{"stepB", "slot"}: "/",
-				{"stepD", "slot"}: "/1",
+			Inputs: map[api.AbsPath]api.SlotRef{
+				"/":  {"stepB", "slot"},
+				"/1": {"stepD", "slot"},
 			},
 			Outputs: map[api.SlotName]api.AbsPath{"slot": "/"},
 		},
 		"stepF": api.Operation{
-			Inputs: map[api.SlotRef]api.AbsPath{
-				{"stepD", "slot"}: "/",
+			Inputs: map[api.AbsPath]api.SlotRef{
+				"/": {"stepD", "slot"},
 			},
 			Outputs: map[api.SlotName]api.AbsPath{"slot": "/"},
 		},
 		"stepG": api.Operation{
-			Inputs: map[api.SlotRef]api.AbsPath{
-				{"stepF", "slot"}: "/",
+			Inputs: map[api.AbsPath]api.SlotRef{
+				"/": {"stepF", "slot"},
 			},
 			Outputs: map[api.SlotName]api.AbsPath{"slot": "/"},
 		},
 		"stepH": api.Operation{
-			Inputs: map[api.SlotRef]api.AbsPath{
-				{"stepE", "slot"}: "/",
+			Inputs: map[api.AbsPath]api.SlotRef{
+				"/": {"stepE", "slot"},
 			},
 			Outputs: map[api.SlotName]api.AbsPath{"slot": "/"},
 		},
 		"stepI": api.Operation{
-			Inputs: map[api.SlotRef]api.AbsPath{
-				{"stepF", "slot"}: "/",
+			Inputs: map[api.AbsPath]api.SlotRef{
+				"/": {"stepF", "slot"},
 			},
 			Outputs: map[api.SlotName]api.AbsPath{"slot": "/"},
 		},
 		"stepJ": api.Operation{
-			Inputs: map[api.SlotRef]api.AbsPath{
-				{"stepF", "slot"}: "/",
+			Inputs: map[api.AbsPath]api.SlotRef{
+				"/": {"stepF", "slot"},
 			},
 			Outputs: map[api.SlotName]api.AbsPath{"slot": "/"},
 		},
 		"stepK": api.Operation{
-			Inputs: map[api.SlotRef]api.AbsPath{
-				{"stepE", "slot"}: "/",
+			Inputs: map[api.AbsPath]api.SlotRef{
+				"/": {"stepE", "slot"},
 			},
 			Outputs: map[api.SlotName]api.AbsPath{"slot": "/"},
 		},
 		"stepL": api.Operation{
-			Inputs: map[api.SlotRef]api.AbsPath{
-				{"stepG", "slot"}: "/",
-				{"stepK", "slot"}: "/1",
-				{"stepH", "slot"}: "/2",
+			Inputs: map[api.AbsPath]api.SlotRef{
+				"/":  {"stepG", "slot"},
+				"/1": {"stepK", "slot"},
+				"/2": {"stepH", "slot"},
 			},
 			Outputs: map[api.SlotName]api.AbsPath{"slot": "/"},
 		},
 		"stepM": api.Operation{
-			Inputs: map[api.SlotRef]api.AbsPath{
-				{"stepI", "slot"}: "/",
-				{"stepJ", "slot"}: "/1",
+			Inputs: map[api.AbsPath]api.SlotRef{
+				"/":  {"stepI", "slot"},
+				"/1": {"stepJ", "slot"},
 			},
 			Outputs: map[api.SlotName]api.AbsPath{"slot": "/"},
 		},
@@ -231,7 +231,7 @@ func TestDeepSubmoduleOrdering(t *testing.T) {
 					},
 				},
 				"midstep": api.Operation{
-					Inputs:  map[api.SlotRef]api.AbsPath{{"deeper", "zowslot"}: "/"},
+					Inputs:  map[api.AbsPath]api.SlotRef{"/": {"deeper", "zowslot"}},
 					Outputs: map[api.SlotName]api.AbsPath{"slot": "/"},
 				},
 			},
@@ -240,8 +240,8 @@ func TestDeepSubmoduleOrdering(t *testing.T) {
 			},
 		},
 		"stepWub": api.Operation{
-			Inputs: map[api.SlotRef]api.AbsPath{
-				{"stepSub", "wowslot"}: "/",
+			Inputs: map[api.AbsPath]api.SlotRef{
+				"/": {"stepSub", "wowslot"},
 			},
 		},
 	}}

--- a/funcs/moduleResolvePins_test.go
+++ b/funcs/moduleResolvePins_test.go
@@ -19,10 +19,10 @@ func TestPinning(t *testing.T) {
 		},
 		Steps: map[StepName]StepUnion{
 			"stepA": Operation{
-				Inputs: map[SlotRef]AbsPath{
-					{"", "base"}: "/",
-					{"", "foo"}:  "/foo",
-					{"", "bar"}:  "/bar",
+				Inputs: map[AbsPath]SlotRef{
+					"/":    {"", "base"},
+					"/foo": {"", "foo"},
+					"/bar": {"", "bar"},
 				},
 				Action: FormulaAction{Exec: []string{"mv", "/foo/thinger", "/out/thinger"}},
 				Outputs: map[SlotName]AbsPath{
@@ -37,10 +37,10 @@ func TestPinning(t *testing.T) {
 				},
 				Steps: map[StepName]StepUnion{
 					"op": Operation{
-						Inputs: map[SlotRef]AbsPath{
-							{"", "base"}:   "/",
-							{"", "bar"}:    "/bar",
-							{"", "wodget"}: "/src",
+						Inputs: map[AbsPath]SlotRef{
+							"/":    {"", "base"},
+							"/bar": {"", "bar"},
+							"/src": {"", "wodget"},
 						},
 						Action: FormulaAction{Exec: []string{"/bar/tool", "/src", "/out/thinger"}},
 						Outputs: map[SlotName]AbsPath{
@@ -51,9 +51,9 @@ func TestPinning(t *testing.T) {
 				Exports: map[ItemName]SlotRef{"barred": {"op", "intermediate"}},
 			},
 			"stepC": Operation{
-				Inputs: map[SlotRef]AbsPath{
-					{"", "base"}:        "/",
-					{"stepB", "barred"}: "/bar",
+				Inputs: map[AbsPath]SlotRef{
+					"/":    {"", "base"},
+					"/bar": {"stepB", "barred"},
 				},
 				Action: FormulaAction{Exec: []string{"/bar/thinger"}},
 				Outputs: map[SlotName]AbsPath{

--- a/moduleSerial_test.go
+++ b/moduleSerial_test.go
@@ -60,7 +60,7 @@ func TestModuleSerialization(t *testing.T) {
 						},
 					},
 					"midstep": Operation{
-						Inputs:  map[SlotRef]AbsPath{{"deeper", "zowslot"}: "/"},
+						Inputs:  map[AbsPath]SlotRef{"/": {"deeper", "zowslot"}},
 						Outputs: map[SlotName]AbsPath{"slot": "/"},
 					},
 				},
@@ -69,8 +69,8 @@ func TestModuleSerialization(t *testing.T) {
 				},
 			},
 			"stepWub": Operation{
-				Inputs: map[SlotRef]AbsPath{
-					{"stepSub", "wowslot"}: "/",
+				Inputs: map[AbsPath]SlotRef{
+					"/": {"stepSub", "wowslot"},
 				},
 			},
 		}}
@@ -126,7 +126,7 @@ func TestModuleSerialization(t *testing.T) {
 								"midstep": {
 									"operation": {
 										"inputs": {
-											"deeper.zowslot": "/"
+											"/": "deeper.zowslot"
 										},
 										"action": {},
 										"outputs": {
@@ -143,7 +143,7 @@ func TestModuleSerialization(t *testing.T) {
 					"stepWub": {
 						"operation": {
 							"inputs": {
-								"stepSub.wowslot": "/"
+								"/": "stepSub.wowslot"
 							},
 							"action": {}
 						}

--- a/operation.go
+++ b/operation.go
@@ -13,7 +13,7 @@ type AbsPath string
 	all specific, concrete WareID hashes instead of SlotRef.
 */
 type Operation struct {
-	Inputs  map[SlotRef]AbsPath
+	Inputs  map[AbsPath]SlotRef
 	Action  FormulaAction
 	Outputs map[SlotName]AbsPath `refmt:",omitempty"`
 }

--- a/operationSerial_test.go
+++ b/operationSerial_test.go
@@ -42,8 +42,8 @@ func TestOperationSerialization(t *testing.T) {
 	})
 	t.Run("examplary operation should roundtrip", func(t *testing.T) {
 		obj := Operation{
-			Inputs: map[SlotRef]AbsPath{
-				SlotRef{"", "foo"}: "/",
+			Inputs: map[AbsPath]SlotRef{
+				"/": SlotRef{"", "foo"},
 			},
 			Action: FormulaAction{
 				Exec: []string{"/script"},
@@ -55,7 +55,7 @@ func TestOperationSerialization(t *testing.T) {
 		canon := Dedent(`
 			{
 				"inputs": {
-					"foo": "/"
+					"/": "foo"
 				},
 				"action": {
 					"exec": [

--- a/repeatr/repeatrDecorators.go
+++ b/repeatr/repeatrDecorators.go
@@ -50,7 +50,7 @@ func RunOperation(
 		Action:  op.Action,
 		Outputs: make(map[api.AbsPath]api.FormulaOutputSpec, len(op.Outputs)),
 	}
-	for slotRef, pth := range op.Inputs {
+	for pth, slotRef := range op.Inputs {
 		pin, ok := scope[slotRef]
 		if !ok {
 			return nil, fmt.Errorf("cannot provide an input ware for slotref %q: no such ref in scope", slotRef)


### PR DESCRIPTION
Previously, Operation.Inputs was in SlotRef:Path ordering.
Putting the SlotRef first scored well for consistency in one regard:
it meant all appearances of a SlotRef were on the *left* in a Module.

However, this was *inconsistent* in another almost every other regard:

- SlotRef:Path ordering of input is in "Value=:Assignment" order.
Every other piece of specification -- import mappings, output mappings,
and export mappings -- in a Module goes in the other way around:
"Assignment:=Value" order.  (This right-to-left "Assignment:=Value"
order is also typical in the majority of modern programming languages.)
Flipping makes assignment order consistent throughout the Module spec
(even if at the cost of consistency in slotref-on-the-left order).

- Repeatr Formulas, one layer down in the API layer model, are
in "Path:Hash" order.  Having the Path on the *left* in Formula.Input
while on the *right* in Operation.Input was staggeringly inconsistent.

- Having the Path as the map *key* is simply *more correct*.
It is invalid to have more than one input mapping into the same path
(see https://github.com/polydawn/stellar/issues/2 !), so we might
as well use the uniqueness of map keys to make this invalid concept
inexpressible.

Most of the diff is simply test fixture updates.

This will, of course, be a breaking change for serialized modules.
We'll have to bite the bullet on that.  It's a pretty quick and
mechanical rewrite, fortunately.

[Stellar](https://github.com/polydawn/stellar/) will need a PR promptly
to match this.  The rest of the Timeless Stack projects are unaffected,
since this is all "layer 2" stuff.